### PR TITLE
feat(comments): implement comment and reply functionality for cocktails

### DIFF
--- a/app/controllers/CocktailController.php
+++ b/app/controllers/CocktailController.php
@@ -9,6 +9,8 @@ require_once __DIR__ . '/../repositories/UnitRepository.php';
 require_once __DIR__ . '/../services/CocktailService.php';
 require_once __DIR__ . '/../services/IngredientService.php';
 require_once __DIR__ . '/../services/StepService.php';
+require_once __DIR__ . '/../services/CommentService.php';
+require_once __DIR__ . '/../repositories/CommentRepository.php';
 
 class CocktailController
 {
@@ -16,6 +18,7 @@ class CocktailController
     private $ingredientService;
     private $stepService;
     private $difficultyRepository;
+    private $commentService;
 
     public function __construct()
     {
@@ -32,11 +35,13 @@ class CocktailController
         $stepRepository = new StepRepository($db);
         $tagRepository = new TagRepository($db);
         $this->difficultyRepository = new DifficultyRepository($db);
-        $unitRepository = new UnitRepository($db);  // Add UnitRepository for units
+        $unitRepository = new UnitRepository($db);  
+        $commentRepository = new CommentRepository($db);
 
         // Initialize services
         $this->ingredientService = new IngredientService($ingredientRepository, $unitRepository);
         $this->stepService = new StepService($stepRepository);
+        $this->commentService = new CommentService($commentRepository); 
 
         // Initialize the CocktailService with services and repositories
         $this->cocktailService = new CocktailService(
@@ -309,6 +314,8 @@ class CocktailController
         $tags = $this->cocktailService->getCocktailTags($cocktailId);
         $categories = $this->cocktailService->getCategories();
         $units = $this->ingredientService->getAllUnits();
+
+        $comments = $this->commentService->getCommentsWithReplies($cocktailId);
 
         if ($isEditing) {
             require_once __DIR__ . '/../views/cocktails/form.php'; // Load the edit form

--- a/app/controllers/CommentController.php
+++ b/app/controllers/CommentController.php
@@ -1,0 +1,77 @@
+<?php
+class CommentController
+{
+    private $commentService;
+
+    public function __construct(CommentService $commentService)
+    {
+        $this->commentService = $commentService;
+    }
+
+    // Add a comment or reply
+    public function addComment($cocktailId)
+    {
+        error_log("addComment method called for cocktail ID: " . $cocktailId); // Add logging
+
+        // Ensure user is logged in
+        $userId = $_SESSION['user']['id'] ?? null;
+        if (!$userId) {
+            $_SESSION['error'] = 'You must be logged in to comment.';
+            header("Location: /login");
+            exit();
+        }
+
+        // Get comment data from POST
+        $commentText = $_POST['comment'] ?? '';
+        $parentCommentId = $_POST['parent_comment_id'] ?? null;
+
+        if (empty($commentText)) {
+            $_SESSION['error'] = 'Comment cannot be empty.';
+            header("Location: /cocktails/{$cocktailId}");
+            exit();
+        }
+
+        // Make sure parent_comment_id is null for top-level comments
+        if (empty($parentCommentId)) {
+            $parentCommentId = null; // Treat top-level comments as having no parent
+        }
+        // Add the comment using service
+        $this->commentService->addComment($userId, $cocktailId, $commentText, $parentCommentId);
+
+        // Redirect back to the cocktail view
+        $cocktailTitle = urlencode($_POST['cocktailTitle']);
+        header("Location: /cocktails/{$cocktailId}-{$cocktailTitle}");
+        exit();
+    }
+
+    // Edit comment
+    public function edit($commentId)
+    {
+        $comment = $this->commentService->getCommentById($commentId);
+
+        // Ensure the user owns the comment or is an admin
+        if ($_SESSION['user']['id'] !== $comment->getUserId() && !AuthController::isAdmin()) {
+            header("Location: /cocktails");
+            exit();
+        }
+
+        // Display edit form (you can load a view here)
+    }
+    public function delete($commentId)
+    {
+        $comment = $this->commentService->getCommentById($commentId);
+
+        // Ensure the user owns the comment or is an admin
+        if ($_SESSION['user']['id'] !== $comment->getUserId() && !AuthController::isAdmin()) {
+            header("Location: /cocktails");
+            exit();
+        }
+
+        // Delete the comment
+        $this->commentService->deleteComment($commentId);
+
+        // Redirect back to the cocktail page
+        header("Location: /cocktails");
+        exit();
+    }
+}

--- a/app/models/Comment.php
+++ b/app/models/Comment.php
@@ -1,0 +1,52 @@
+<?php
+class Comment {
+    private $commentId;
+    private $userId;
+    private $username;
+    private $cocktailId;
+    private $parentCommentId;
+    private $commentText;
+    private $createdAt;
+    public $replies;
+
+    public function __construct($commentId, $userId, $username, $cocktailId, $parentCommentId, $commentText, $createdAt) {
+        $this->commentId = $commentId;
+        $this->userId = $userId;
+        $this->username = $username;
+        $this->cocktailId = $cocktailId;
+        $this->parentCommentId = $parentCommentId;
+        $this->commentText = $commentText;
+        $this->createdAt = $createdAt;
+        $this->replies = []; 
+    }
+
+    // Getters
+    public function getUsername() {
+        return $this->username; 
+    }
+
+    public function getCommentText() {
+        return $this->commentText;
+    }
+
+    public function getCreatedAt() {
+        return $this->createdAt;
+    }
+
+    public function getCommentId() {
+        return $this->commentId;
+    }
+
+    public function getUserId() {
+        return $this->userId;
+    }
+
+    public function getCocktailId() {
+        return $this->cocktailId;
+    }
+
+    public function getParentCommentId() {
+        return $this->parentCommentId;
+    }
+    
+}

--- a/app/repositories/CommentRepository.php
+++ b/app/repositories/CommentRepository.php
@@ -1,0 +1,103 @@
+<?php
+require_once __DIR__ . '/../models/Comment.php';
+class CommentRepository {
+    private $db;
+
+    public function __construct(PDO $db) {
+        $this->db = $db;
+    }
+     // Fetch a comment by its ID
+     public function getCommentById($commentId) {
+        $sql = "SELECT * FROM comments WHERE comment_id = :comment_id";
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':comment_id', $commentId, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_OBJ);
+    }
+    // Fetch top-level comments
+    public function getTopLevelCommentsByCocktailId($cocktailId) {
+        $sql = "
+            SELECT c.*, u.username 
+            FROM comments c
+            JOIN users u ON c.user_id = u.user_id
+            WHERE c.cocktail_id = :cocktail_id AND c.parent_comment_id IS NULL 
+            ORDER BY c.created_at DESC";
+        
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':cocktail_id', $cocktailId, PDO::PARAM_INT);
+        $stmt->execute();
+        $results = $stmt->fetchAll(PDO::FETCH_OBJ);
+
+        // Convert each result to a Comment model
+        $comments = [];
+        foreach ($results as $result) {
+            $comments[] = new Comment(
+                $result->comment_id,
+                $result->user_id,
+                $result->username, 
+                $result->cocktail_id,
+                $result->parent_comment_id,
+                $result->comment,
+                $result->created_at
+            );
+        }
+        return $comments;
+    }
+
+    // Fetch replies for a comment
+    public function getRepliesByCommentId($commentId) {
+        $sql = "
+            SELECT c.*, u.username 
+            FROM comments c
+            JOIN users u ON c.user_id = u.user_id
+            WHERE c.parent_comment_id = :comment_id 
+            ORDER BY c.created_at ASC";
+        
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':comment_id', $commentId, PDO::PARAM_INT);
+        $stmt->execute();
+        $results = $stmt->fetchAll(PDO::FETCH_OBJ);
+
+        // Convert each result to a Comment model
+        $replies = [];
+        foreach ($results as $result) {
+            $replies[] = new Comment(
+                $result->comment_id,
+                $result->user_id,
+                $result->username, 
+                $result->cocktail_id,
+                $result->parent_comment_id,
+                $result->comment,
+                $result->created_at
+            );
+        }
+        return $replies;
+    }
+
+    // Add a new comment
+    public function addComment($userId, $cocktailId, $commentText, $parentCommentId = null) {
+        try {
+            $sql = "INSERT INTO comments (user_id, cocktail_id, comment, parent_comment_id) 
+                    VALUES (:user_id, :cocktail_id, :comment, :parent_comment_id)";
+            $stmt = $this->db->prepare($sql);
+            $stmt->bindParam(':user_id', $userId);
+            $stmt->bindParam(':cocktail_id', $cocktailId);
+            $stmt->bindParam(':comment', $commentText);
+            $stmt->bindParam(':parent_comment_id', $parentCommentId);
+            
+            $result = $stmt->execute();
+            error_log("Comment Inserted: " . json_encode($stmt->errorInfo())); // Log the error info if any
+            return $result;
+        } catch (PDOException $e) {
+            error_log("Database error: " . $e->getMessage()); // Log the exception
+            return false;
+        }
+    }
+     // Delete a comment by its ID
+     public function deleteComment($commentId) {
+        $sql = "DELETE FROM comments WHERE comment_id = :comment_id";
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':comment_id', $commentId, PDO::PARAM_INT);
+        return $stmt->execute();
+    }
+}

--- a/app/services/CommentService.php
+++ b/app/services/CommentService.php
@@ -1,0 +1,39 @@
+<?php
+class CommentService
+{
+    private $commentRepository;
+
+    public function __construct(CommentRepository $commentRepository)
+    {
+        $this->commentRepository = $commentRepository;
+    }
+    // Fetch a comment by its ID
+    public function getCommentById($commentId)
+    {
+        return $this->commentRepository->getCommentById($commentId);
+    }
+    // Fetch all comments, including replies
+    public function getCommentsWithReplies($cocktailId)
+    {
+        // Fetch top-level comments
+        $comments = $this->commentRepository->getTopLevelCommentsByCocktailId($cocktailId);
+
+        // For each top-level comment, fetch its replies and assign them
+        foreach ($comments as $comment) {
+            $replies = $this->commentRepository->getRepliesByCommentId($comment->getCommentId());
+            $comment->replies = $replies; // Assign replies to the Comment object
+        }
+
+        return $comments;
+    }
+
+    // Add a comment
+    public function addComment($userId, $cocktailId, $commentText, $parentCommentId = null) {
+        return $this->commentRepository->addComment($userId, $cocktailId, $commentText, $parentCommentId);
+    }
+    // Delete a comment by its ID
+    public function deleteComment($commentId)
+    {
+        return $this->commentRepository->deleteComment($commentId);
+    }
+}

--- a/app/views/cocktails/view.php
+++ b/app/views/cocktails/view.php
@@ -19,8 +19,7 @@ $units = $units ?? [];
             <p><?= htmlspecialchars($error) ?></p>
         <?php endforeach; ?>
     </div>
-    <?php unset($_SESSION['errors']); 
-    ?>
+    <?php unset($_SESSION['errors']); ?>
 <?php endif; ?>
 
 <div class="cocktail-actions">
@@ -79,8 +78,8 @@ $units = $units ?? [];
         <button id="editCocktailButton" class="text-blue-500 hover:underline">
             Edit Cocktail
         </button>
-         <!-- Delete Button -->
-         <form action="/cocktails/delete/<?= $cocktail->getCocktailId() ?>" method="post" onsubmit="return confirm('Are you sure you want to delete this cocktail?');">
+        <!-- Delete Button -->
+        <form action="/cocktails/delete/<?= $cocktail->getCocktailId() ?>" method="post" onsubmit="return confirm('Are you sure you want to delete this cocktail?');">
             <button type="submit" class="text-red-500 hover:underline">Delete Cocktail</button>
         </form>
     <?php endif; ?>
@@ -88,11 +87,71 @@ $units = $units ?? [];
     <!-- Hidden Form (inline editing) -->
     <div id="editFormContainer" style="display: none;">
         <?php
-        // Ensure $isEditing is true and include the form
         $isEditing = true;
         include __DIR__ . '/form.php';
         ?>
     </div>
+  
+    <!-- Display Comments Section -->
+    <h2 class="text-2xl font-semibold mt-6 mb-2">Comments</h2>
+    <div class="comments-section">
+        <?php if (!empty($comments)): ?>
+            <?php foreach ($comments as $comment): ?>
+                <div class="comment-box">
+                    <div class="comment">
+                        <p><strong><?= htmlspecialchars($comment->getUsername() ?? 'Unknown User') ?>:</strong></p>
+                        <p><?= htmlspecialchars($comment->getCommentText() ?? 'No comment text available') ?></p>
+                        <p class="comment-date"><small>Posted on <?= htmlspecialchars($comment->getCreatedAt() ?? 'Unknown date') ?></small></p>
 
+                        <!-- Dots Menu -->
+                        <?php if (isset($_SESSION['user']['id']) && ($_SESSION['user']['id'] === $comment->getUserId() || AuthController::isAdmin())): ?>
+                            <div class="dots-menu">
+                                <button class="dots-button">⋮</button>
+                                <div class="menu hidden">
+                                    <a href="/comments/<?= $comment->getCommentId() ?>/edit" class="menu-item">Edit</a>
+                                    <form action="/comments/<?= $comment->getCommentId() ?>/delete" method="POST" onsubmit="return confirm('Are you sure you want to delete this comment?');">
+                                        <button type="submit" class="menu-item">Delete</button>
+                                    </form>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+
+                    <!-- Replies Section -->
+                    <?php if (!empty($comment->replies)): ?>
+                        <div class="replies-section" style="margin-left: 20px;"> <!-- Indentation for replies -->
+                            <?php foreach ($comment->replies as $reply): ?>
+                                <div class="reply">
+                                    <p><strong><?= htmlspecialchars($reply->getUsername() ?? 'Unknown User') ?>:</strong></p>
+                                    <p><?= htmlspecialchars($reply->getCommentText() ?? 'No reply text available') ?></p>
+                                    <p class="comment-date"><small>Posted on <?= htmlspecialchars($reply->getCreatedAt() ?? 'Unknown date') ?></small></p>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <!-- Reply Form -->
+                    <form action="/cocktails/<?= htmlspecialchars($cocktail->getCocktailId()) ?>-<?= urlencode($cocktail->getTitle()) ?>/comments" method="POST">
+                        <textarea name="comment" placeholder="Write your reply here..." required></textarea>
+                        <input type="hidden" name="parent_comment_id" value="<?= htmlspecialchars($comment->getCommentId()) ?>">
+                        <input type="hidden" name="cocktailTitle" value="<?= htmlspecialchars($cocktail->getTitle()) ?>">
+                        <button type="submit">Reply</button>
+                    </form>
+                </div>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <p>No comments yet. Be the first to comment!</p>
+        <?php endif; ?>
+    </div>
+
+    <!-- Add Top-level Comment Form -->
+    <h3>Add a New Comment</h3>
+    <form action="/cocktails/<?= htmlspecialchars($cocktail->getCocktailId()) ?>-<?= urlencode($cocktail->getTitle()) ?>/comments" method="POST">
+        <textarea name="comment" placeholder="Write your comment here..." required></textarea>
+        <input type="hidden" name="parent_comment_id" value=""> 
+        <input type="hidden" name="cocktailTitle" value="<?= htmlspecialchars($cocktail->getTitle()) ?>">
+        <button type="submit">Submit</button>
+    </form>
 </div>
+
 <?php include __DIR__ . '/../layout/footer.php'; ?>

--- a/app/views/layout/footer.php
+++ b/app/views/layout/footer.php
@@ -5,6 +5,7 @@
 </footer>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="<?= asset('assets/js/cocktail.js'); ?>"></script>
+<script src="<?= asset('assets/js/comments.js'); ?>"></script>
 
 </body>
 </html>

--- a/database/sql/schema.sql
+++ b/database/sql/schema.sql
@@ -148,7 +148,7 @@ CREATE TABLE `comments` (
   `comment_id` int PRIMARY KEY AUTO_INCREMENT,
   `user_id` int,
   `cocktail_id` int,
-  `parent_comment_id` int,
+  `parent_comment_id` int DEFAULT NULL, -- Allow NULL for top-level comments
   `comment` text NOT NULL,
   `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (`user_id`) REFERENCES `users`(`user_id`) ON DELETE CASCADE,

--- a/public/assets/css/components/comments.css
+++ b/public/assets/css/components/comments.css
@@ -1,0 +1,39 @@
+/* Dots Menu Styling */
+.dots-menu {
+    position: relative;
+    display: inline-block;
+}
+
+.dots-button {
+    background: none;
+    border: none;
+    font-size: 1.5em;
+    cursor: pointer;
+}
+
+.menu {
+    position: absolute;
+    top: 20px;
+    right: 0;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    padding: 5px;
+    border-radius: 5px;
+    display: none;
+    z-index: 10;
+}
+
+.menu.active {
+    display: block;
+}
+
+.menu-item {
+    display: block;
+    padding: 5px 10px;
+    color: #333;
+    text-decoration: none;
+}
+
+.menu-item:hover {
+    background-color: #f1f1f1;
+}

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -3,6 +3,7 @@
 @import '../css/components/forms.css';
 @import '../css/pages/cocktails.css';
 @import '../css/pages/footer.css';
+@import '../css/components/comments.css';
 :root {
     /* Colors for Light Mode */
     --background: #f2f2f2;

--- a/public/assets/js/comments.js
+++ b/public/assets/js/comments.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const dotsButtons = document.querySelectorAll('.dots-button');
+
+    dotsButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            const menu = this.nextElementSibling;
+            menu.classList.toggle('active'); // Toggle menu visibility
+        });
+    });
+
+    // Close the menu if clicked outside
+    document.addEventListener('click', function(event) {
+        if (!event.target.matches('.dots-button')) {
+            const menus = document.querySelectorAll('.menu');
+            menus.forEach(menu => {
+                menu.classList.remove('active'); // Hide other menus
+            });
+        }
+    });
+});

--- a/routes.php
+++ b/routes.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/app/controllers/HomeController.php';
 require_once __DIR__ . '/app/controllers/UserController.php';
 require_once __DIR__ . '/app/controllers/AuthController.php';
 require_once __DIR__ . '/app/controllers/CocktailController.php';
+require_once __DIR__ . '/app/controllers/CommentController.php';
 
 $router = new Router(); // Instantiate the Router class
 
@@ -37,3 +38,7 @@ $router->add('POST', '#^/cocktails/(\d+)/delete-step$#', [CocktailController::cl
 $router->add('GET', '#^/cocktails$#', [CocktailController::class, 'index']); // List all cocktails
 $router->add('GET', '#^/cocktails/(\d+)-(.+)$#', [CocktailController::class, 'view']); // View specific cocktail
 
+// Comment interactions
+$router->add('POST', '#^/cocktails/(\d+)-[^/]+/comments$#', [CommentController::class, 'addComment']);
+$router->add('GET', '#^/comments/(\d+)/edit$#', [CommentController::class, 'edit']); // Edit comment
+$router->add('POST', '#^/comments/(\d+)/delete$#', [CommentController::class, 'delete']); // Delete comment


### PR DESCRIPTION
### Add Comment and Reply Functionality to Cocktail Posts

#### Description:
This PR implements the ability for users to add comments and reply to existing comments on cocktail posts. The comment and reply functionality is fully integrated with the existing database and front-end views.

#### What's Included:
- Users can add new comments to cocktail posts.
- Users can reply to existing comments.
- Comments and replies are displayed with proper indentation to distinguish parent comments from replies.

#### Known Issues:
- Edit and Delete functionality for comments and replies is not yet implemented.
  
#### Testing:
- Add comments to a cocktail post and verify they appear in the comments section.
- Reply to an existing comment and check if the reply is indented beneath the original comment.